### PR TITLE
Updates for powering Turret Bases, no more IC2, but GT5

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,11 +3,11 @@
 dependencies {
     implementation("curse.maven:cofh-lib-220333:2388748")
 
-    compileOnly 'com.github.GTNewHorizons:waila:1.8.1:dev'
-    compileOnly 'com.github.GTNewHorizons:NotEnoughItems:2.6.35-GTNH:dev'
-    compileOnly 'com.github.GTNewHorizons:OpenComputers:1.10.23-GTNH:dev'
-    compileOnly 'net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev'
-    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.00:dev")
-    compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
-    compileOnly("curse.maven:computercraft-67504:2269339")
+    devOnlyNonPublishable  'com.github.GTNewHorizons:waila:1.8.2:dev'
+    devOnlyNonPublishable  'com.github.GTNewHorizons:NotEnoughItems:2.6.51-GTNH:dev'
+    devOnlyNonPublishable  'com.github.GTNewHorizons:OpenComputers:1.10.27-GTNH:dev'
+    devOnlyNonPublishable  'net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev'
+    devOnlyNonPublishable ("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.00:dev")
+    devOnlyNonPublishable ("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
+    devOnlyNonPublishable ("curse.maven:computercraft-67504:2269339")
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ dependencies {
     compileOnly 'com.github.GTNewHorizons:NotEnoughItems:2.6.35-GTNH:dev'
     compileOnly 'com.github.GTNewHorizons:OpenComputers:1.10.23-GTNH:dev'
     compileOnly 'net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev'
+    compileOnly("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.00:dev")
     compileOnly("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly("curse.maven:computercraft-67504:2269339")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.27'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
 }
 
 

--- a/src/main/java/openmodularturrets/compatability/ModCompatibility.java
+++ b/src/main/java/openmodularturrets/compatability/ModCompatibility.java
@@ -24,6 +24,7 @@ public class ModCompatibility {
     public static boolean OpenComputersLoaded = false;
     public static boolean ComputercraftLoaded = false;
     public static boolean IC2Loaded = false;
+    public static boolean GTLoaded = false;
     private static Logger logger;
 
     public static void checkForMods() {
@@ -55,6 +56,13 @@ public class ModCompatibility {
             logger.info("Enabling LUA integration. (Found OpenComputers/ComputerCraft)");
         }
         IC2Loaded = Loader.isModLoaded("IC2");
+        if (IC2Loaded) {
+            logger.info("I'm not a doctor, but I think you have a case of IC2. (Found IC2)");
+        }
+        GTLoaded = Loader.isModLoaded("gregtech");
+        if (GTLoaded) {
+            logger.info("Oh you like doing things the hard way? (Found Gregtech)");
+        }
     }
 
     private static void addVersionCheckerInfo() {


### PR DESCRIPTION
This removes the partially broken IC2 Power Integration and instead adds the GT5 Power Integration.
Also updated the buildscript and the depdencies to the most recent versions.