### PR TITLE
improve targeting by reworking onImpact for projectiles

### DIFF
--- a/src/main/java/openmodularturrets/blocks/turretheads/BlockAbstractTurretHead.java
+++ b/src/main/java/openmodularturrets/blocks/turretheads/BlockAbstractTurretHead.java
@@ -11,7 +11,7 @@ import net.minecraft.world.World;
 import openmodularturrets.ModularTurrets;
 import openmodularturrets.tileentity.turretbase.TurretBase;
 
-abstract class BlockAbstractTurretHead extends Block implements ITileEntityProvider {
+public abstract class BlockAbstractTurretHead extends Block implements ITileEntityProvider {
 
     private static final AxisAlignedBB boundingBox = AxisAlignedBB.getBoundingBox(0.2F, 0.2F, 0.2F, 0.8F, 0.8F, 0.8F);
 

--- a/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
@@ -11,6 +11,7 @@ import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
+import openmodularturrets.blocks.turretheads.BlockAbstractTurretHead;
 import openmodularturrets.entity.projectiles.damagesources.NormalDamageSource;
 import openmodularturrets.handler.ConfigHandler;
 import openmodularturrets.tileentity.turretbase.TurretBase;
@@ -36,14 +37,12 @@ public class BlazingClayProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
-        if (this.ticksExisted <= 1) {
-            return;
-        }
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
             Block hitBlock = worldObj
                     .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null && !hitBlock.getMaterial().isSolid()) {
-                // Go through non solid block
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+                // Go through non-solid block or turrets
                 return;
             }
         }

--- a/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
+import openmodularturrets.blocks.turretheads.BlockAbstractTurretHead;
 import openmodularturrets.entity.projectiles.damagesources.NormalDamageSource;
 import openmodularturrets.handler.ConfigHandler;
 import openmodularturrets.tileentity.turretbase.TurretBase;
@@ -34,14 +35,12 @@ public class BulletProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
-        if (this.ticksExisted <= 1) {
-            return;
-        }
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
             Block hitBlock = worldObj
                     .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null && !hitBlock.getMaterial().isSolid()) {
-                // Go through non solid block
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+                // Go through non-solid block or turrets
                 return;
             }
         }

--- a/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
@@ -8,6 +8,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
+import openmodularturrets.blocks.turretheads.BlockAbstractTurretHead;
 import openmodularturrets.entity.projectiles.damagesources.NormalDamageSource;
 import openmodularturrets.handler.ConfigHandler;
 import openmodularturrets.tileentity.turretbase.TurretBase;
@@ -46,14 +47,12 @@ public class DisposableTurretProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
-        if (this.ticksExisted <= 2) {
-            return;
-        }
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
             Block hitBlock = worldObj
                     .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null && !hitBlock.getMaterial().isSolid()) {
-                // Go through non solid block
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+                // Go through non-solid block or turrets
                 return;
             }
         }

--- a/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
@@ -9,6 +9,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
+import openmodularturrets.blocks.turretheads.BlockAbstractTurretHead;
 import openmodularturrets.entity.projectiles.damagesources.ArmorBypassDamageSource;
 import openmodularturrets.handler.ConfigHandler;
 import openmodularturrets.tileentity.turretbase.TurretBase;
@@ -34,14 +35,12 @@ public class FerroSlugProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
-        if (this.ticksExisted <= 1) {
-            return;
-        }
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
             Block hitBlock = worldObj
                     .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null && !hitBlock.getMaterial().isSolid()) {
-                // Go through non solid block
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+                // Go through non-solid block or turrets
                 return;
             }
         }

--- a/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
+import openmodularturrets.blocks.turretheads.BlockAbstractTurretHead;
 import openmodularturrets.entity.projectiles.damagesources.NormalDamageSource;
 import openmodularturrets.handler.ConfigHandler;
 import openmodularturrets.tileentity.turretbase.TurretBase;
@@ -41,14 +42,12 @@ public class LaserProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
-        if (this.ticksExisted <= 1) {
-            return;
-        }
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
             Block hitBlock = worldObj
                     .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null && !hitBlock.getMaterial().isSolid()) {
-                // Go through non solid block
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+                // Go through non-solid block or turrets
                 return;
             }
         }


### PR DESCRIPTION
Previously projectiles could not hit anything if they hit it in the first tick after being spawned.
This was historically put in that they did not collide with the turret block that was shooting them.

I changed it instead to check if the hitBlock is a turret head. If it is (or non-solid) it will skip the impact and the projectile will continue flying.

Tested it, it improves turrets as they can now hit targets that are very close to them. No difference with far away targets.