### PR TITLE
  Add Kill Count Tracking and GUI Updates for TurretBase

### DIFF
--- a/src/main/java/openmodularturrets/client/gui/ConfigureGui.java
+++ b/src/main/java/openmodularturrets/client/gui/ConfigureGui.java
@@ -342,8 +342,6 @@ public class ConfigureGui extends GuiContainer {
 
         textFieldAddTrustedPlayer.drawTextBox();
 
-        fontRenderer.drawString("Kills: " + base.getKillCount(), 10, 160, 0);
-
         int k = (this.width - this.xSize) / 2;
         int l = (this.height - this.ySize) / 2;
 

--- a/src/main/java/openmodularturrets/client/gui/ConfigureGui.java
+++ b/src/main/java/openmodularturrets/client/gui/ConfigureGui.java
@@ -342,6 +342,8 @@ public class ConfigureGui extends GuiContainer {
 
         textFieldAddTrustedPlayer.drawTextBox();
 
+        fontRenderer.drawString("Kills: " + base.getKillCount(), 10, 160, 0);
+
         int k = (this.width - this.xSize) / 2;
         int l = (this.height - this.ySize) / 2;
 

--- a/src/main/java/openmodularturrets/client/gui/TurretBaseTierFiveGui.java
+++ b/src/main/java/openmodularturrets/client/gui/TurretBaseTierFiveGui.java
@@ -63,6 +63,9 @@ public class TurretBaseTierFiveGui extends TurretBaseAbstractGui {
         targetInfo.add("\u00A77Attack Neutrals: \u00A7b" + base.isAttacksNeutrals());
         targetInfo.add("\u00A77Attack Players: \u00A7b" + base.isAttacksPlayers());
 
+        targetInfo.add("");
+        targetInfo.add("\u00A77Kill Count: \u00A7b" + base.getKillCount());
+
         this.drawHoveringText(targetInfo, -128, 17, fontRenderer);
     }
 

--- a/src/main/java/openmodularturrets/client/gui/TurretBaseTierFourGui.java
+++ b/src/main/java/openmodularturrets/client/gui/TurretBaseTierFourGui.java
@@ -62,6 +62,8 @@ public class TurretBaseTierFourGui extends TurretBaseAbstractGui {
         targetInfo.add("\u00A77Attack Mobs: \u00A7b" + base.isAttacksMobs());
         targetInfo.add("\u00A77Attack Neutrals: \u00A7b" + base.isAttacksNeutrals());
         targetInfo.add("\u00A77Attack Players: \u00A7b" + base.isAttacksPlayers());
+        targetInfo.add("");
+        targetInfo.add("\u00A77Kill Count: \u00A7b" + base.getKillCount());
 
         this.drawHoveringText(targetInfo, -128, 17, fontRenderer);
     }

--- a/src/main/java/openmodularturrets/client/gui/TurretBaseTierOneGui.java
+++ b/src/main/java/openmodularturrets/client/gui/TurretBaseTierOneGui.java
@@ -61,6 +61,8 @@ public class TurretBaseTierOneGui extends TurretBaseAbstractGui {
         targetInfo.add("\u00A77Attack Mobs: \u00A7b" + base.isAttacksMobs());
         targetInfo.add("\u00A77Attack Neutrals: \u00A7b" + base.isAttacksNeutrals());
         targetInfo.add("\u00A77Attack Players: \u00A7b" + base.isAttacksPlayers());
+        targetInfo.add("");
+        targetInfo.add("\u00A77Kill Count: \u00A7b" + base.getKillCount());
 
         this.drawHoveringText(targetInfo, -128, 17, fontRenderer);
     }

--- a/src/main/java/openmodularturrets/client/gui/TurretBaseTierThreeGui.java
+++ b/src/main/java/openmodularturrets/client/gui/TurretBaseTierThreeGui.java
@@ -62,6 +62,8 @@ public class TurretBaseTierThreeGui extends TurretBaseAbstractGui {
         targetInfo.add("\u00A77Attack Mobs: \u00A7b" + base.isAttacksMobs());
         targetInfo.add("\u00A77Attack Neutrals: \u00A7b" + base.isAttacksNeutrals());
         targetInfo.add("\u00A77Attack Players: \u00A7b" + base.isAttacksPlayers());
+        targetInfo.add("");
+        targetInfo.add("\u00A77Kill Count: \u00A7b" + base.getKillCount());
 
         this.drawHoveringText(targetInfo, -128, 17, fontRenderer);
     }

--- a/src/main/java/openmodularturrets/client/gui/TurretBaseTierTwoGui.java
+++ b/src/main/java/openmodularturrets/client/gui/TurretBaseTierTwoGui.java
@@ -62,6 +62,8 @@ public class TurretBaseTierTwoGui extends TurretBaseAbstractGui {
         targetInfo.add("\u00A77Attack Mobs: \u00A7b" + base.isAttacksMobs());
         targetInfo.add("\u00A77Attack Neutrals: \u00A7b" + base.isAttacksNeutrals());
         targetInfo.add("\u00A77Attack Players: \u00A7b" + base.isAttacksPlayers());
+        targetInfo.add("");
+        targetInfo.add("\u00A77Kill Count: \u00A7b" + base.getKillCount());
 
         this.drawHoveringText(targetInfo, -128, 17, fontRenderer);
     }

--- a/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
@@ -68,35 +68,48 @@ public class BlazingClayProjectile extends TurretProjectile {
 
             int damage = ConfigHandler.getIncendiary_turret().getDamage();
 
-            if (isAmped) {
-                if (movingobjectposition.entityHit instanceof EntityLivingBase) {
-                    EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
-                    damage += ((int) elb.getHealth() * (0.05 * amp_level));
-                }
+            if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
+                EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
+                damage += ((int) elb.getHealth() * (0.05 * amp_level));
             }
-
 
             for (Entity mob : targets) {
                 boolean wasAlive = !mob.isDead;
-                if (mob instanceof EntityPlayer) {
-                    if (canDamagePlayer((EntityPlayer) mob)) {
-                        mob.attackEntityFrom(new NormalDamageSource("bullet"), damage);
-                        mob.hurtResistantTime = 0;
-                        mob.setFire(5);
+                float healthBefore = 0;
+
+                if (mob instanceof EntityLivingBase) {
+                    EntityLivingBase elb = (EntityLivingBase) mob;
+                    healthBefore = elb.getHealth();
+
+                    if (mob instanceof EntityPlayer) {
+                        if (canDamagePlayer((EntityPlayer) mob)) {
+                            elb.attackEntityFrom(new NormalDamageSource("bullet"), damage);
+                            elb.hurtResistantTime = 0;
+                            elb.setFire(5);
+                        }
+                    } else {
+                        elb.attackEntityFrom(new NormalDamageSource("bullet"), damage);
+                        elb.hurtResistantTime = 0;
+                        elb.setFire(5);
+                    }
+
+                    float healthAfter = elb.getHealth();
+                    if (wasAlive && healthBefore > 0 && healthAfter <= 0) {
+                        turretBase.onKill(mob);
                     }
                 } else {
+                    // Handle non-living base entities
                     mob.attackEntityFrom(new NormalDamageSource("bullet"), damage);
                     mob.hurtResistantTime = 0;
                     mob.setFire(5);
-                }
 
-                if (wasAlive && mob.isDead) {
-                    turretBase.onKill(mob);  // Ensure turretBase is accessible
+                    if (wasAlive && mob.isDead) {
+                        turretBase.onKill(mob);
+                    }
                 }
             }
         }
         this.setDead();
-
     }
 
     @Override

--- a/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
@@ -81,7 +81,7 @@ public class BlazingClayProjectile extends TurretProjectile {
                     EntityLivingBase elb = (EntityLivingBase) mob;
                     healthBefore = elb.getHealth();
 
-                    if (!(mob instanceof EntityPlayer) || canDamagePlayer((EntityPlayer) player)) {
+                    if (!(mob instanceof EntityPlayer) || canDamagePlayer((EntityPlayer) mob)) {
                         elb.attackEntityFrom(new NormalDamageSource("bullet"), damage);
                         elb.hurtResistantTime = 0;
                         elb.setFire(5);

--- a/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
@@ -81,13 +81,7 @@ public class BlazingClayProjectile extends TurretProjectile {
                     EntityLivingBase elb = (EntityLivingBase) mob;
                     healthBefore = elb.getHealth();
 
-                    if (mob instanceof EntityPlayer) {
-                        if (canDamagePlayer((EntityPlayer) mob)) {
-                            elb.attackEntityFrom(new NormalDamageSource("bullet"), damage);
-                            elb.hurtResistantTime = 0;
-                            elb.setFire(5);
-                        }
-                    } else {
+                    if (!(mob instanceof EntityPlayer) || canDamagePlayer((EntityPlayer) player)) {
                         elb.attackEntityFrom(new NormalDamageSource("bullet"), damage);
                         elb.hurtResistantTime = 0;
                         elb.setFire(5);

--- a/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BlazingClayProjectile.java
@@ -75,8 +75,9 @@ public class BlazingClayProjectile extends TurretProjectile {
                 }
             }
 
-            for (Entity mob : targets) {
 
+            for (Entity mob : targets) {
+                boolean wasAlive = !mob.isDead;
                 if (mob instanceof EntityPlayer) {
                     if (canDamagePlayer((EntityPlayer) mob)) {
                         mob.attackEntityFrom(new NormalDamageSource("bullet"), damage);
@@ -88,9 +89,14 @@ public class BlazingClayProjectile extends TurretProjectile {
                     mob.hurtResistantTime = 0;
                     mob.setFire(5);
                 }
+
+                if (wasAlive && mob.isDead) {
+                    turretBase.onKill(mob);  // Ensure turretBase is accessible
+                }
             }
         }
         this.setDead();
+
     }
 
     @Override

--- a/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
@@ -54,6 +54,8 @@ public class BulletProjectile extends TurretProjectile {
         if (movingobjectposition.entityHit != null && !worldObj.isRemote) {
             // Determine final damage
             int damage = ConfigHandler.getGunTurretSettings().getDamage();
+            boolean wasAlive = !movingobjectposition.entityHit.isDead;
+
             if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
                 EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
                 damage += ((int) elb.getHealth() * (0.1 * amp_level));
@@ -79,7 +81,7 @@ public class BulletProjectile extends TurretProjectile {
 
                 // Check if the entity was killed
                 float healthAfter = elb.getHealth();
-                if (healthBefore > 0 && healthAfter <= 0) {
+                if (wasAlive && healthBefore > 0 && healthAfter <= 0) {
                     // If final blow, increment kill count or handle kill logic
                     turretBase.onKill(elb);
                 }

--- a/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
@@ -74,6 +74,9 @@ public class BulletProjectile extends TurretProjectile {
                 movingobjectposition.entityHit.hurtResistantTime = 0;
             }
         }
+        if (movingobjectposition.entityHit.isDead) {
+            turretBase.onKill(movingobjectposition.entityHit);
+        }
 
         if (movingobjectposition.entityHit == null && !worldObj.isRemote) {
             Random random = new Random();

--- a/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/BulletProjectile.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
@@ -35,49 +36,60 @@ public class BulletProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
+        EntityPlayer player = worldObj.getClosestPlayerToEntity(this, 50); // Closest player (if needed)
+
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
             Block hitBlock = worldObj
                     .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
             if (hitBlock != null
                     && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
-                // Go through non-solid block or turrets
-                return;
+                if (player != null) {
+                    player.addChatMessage(new ChatComponentText("Hit non-solid block or turret head"));
+                }
+                return; // Stop if hitting a non-solid block or turret head
             }
         }
 
+        // Check if we hit an entity and we're on the server side
         if (movingobjectposition.entityHit != null && !worldObj.isRemote) {
-            if (movingobjectposition.typeOfHit.equals(0)) {
-                if (worldObj.isAirBlock(
-                        movingobjectposition.blockX,
-                        movingobjectposition.blockY,
-                        movingobjectposition.blockZ)) {
+            // Determine final damage
+            int damage = ConfigHandler.getGunTurretSettings().getDamage();
+            if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
+                EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
+                damage += ((int) elb.getHealth() * (0.1 * amp_level));
+            }
+
+            // Check if it's a player and if we can damage them
+            if (movingobjectposition.entityHit instanceof EntityPlayer) {
+                if (!canDamagePlayer((EntityPlayer) movingobjectposition.entityHit)) {
+                    // If we can't damage the player, exit early
                     return;
                 }
             }
 
-            int damage = ConfigHandler.getGunTurretSettings().getDamage();
+            // Single damage call
+            if (movingobjectposition.entityHit instanceof EntityLivingBase) {
+                EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
+                // Track health before dealing damage
+                float healthBefore = elb.getHealth();
 
-            if (isAmped) {
-                if (movingobjectposition.entityHit instanceof EntityLivingBase) {
-                    EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
-                    damage += ((int) elb.getHealth() * (0.1 * amp_level));
-                }
-            }
+                // Deal damage once
+                elb.attackEntityFrom(new NormalDamageSource("bullet"), damage);
+                elb.hurtResistantTime = 0;
 
-            if (movingobjectposition.entityHit instanceof EntityPlayer) {
-                if (canDamagePlayer((EntityPlayer) movingobjectposition.entityHit)) {
-                    movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("bullet"), damage);
-                    movingobjectposition.entityHit.hurtResistantTime = 0;
+                // Check if the entity was killed
+                float healthAfter = elb.getHealth();
+                if (healthBefore > 0 && healthAfter <= 0) {
+                    // If final blow, increment kill count or handle kill logic
+                    turretBase.onKill(elb);
                 }
             } else {
+                // If the hit entity is not a LivingEntity, just deal damage once
                 movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("bullet"), damage);
-                movingobjectposition.entityHit.hurtResistantTime = 0;
             }
         }
-        if (movingobjectposition.entityHit.isDead) {
-            turretBase.onKill(movingobjectposition.entityHit);
-        }
 
+        // If we didn't hit an entity, play a sound (optional)
         if (movingobjectposition.entityHit == null && !worldObj.isRemote) {
             Random random = new Random();
             worldObj.playSoundEffect(
@@ -88,6 +100,8 @@ public class BulletProjectile extends TurretProjectile {
                     ConfigHandler.getTurretSoundVolume(),
                     random.nextFloat() + 0.5F);
         }
+
+        // Destroy the projectile after impact
         this.setDead();
     }
 

--- a/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
@@ -57,6 +57,8 @@ public class DisposableTurretProjectile extends TurretProjectile {
             }
         }
 
+
+
         if (movingobjectposition.entityHit != null && !worldObj.isRemote) {
             if (movingobjectposition.typeOfHit.equals(0)) {
                 if (worldObj.isAirBlock(
@@ -85,7 +87,11 @@ public class DisposableTurretProjectile extends TurretProjectile {
                 movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("disposable"), damage);
                 movingobjectposition.entityHit.hurtResistantTime = 0;
             }
+            if (movingobjectposition.entityHit.isDead) {
+                turretBase.onKill(movingobjectposition.entityHit);
+            }
         }
+
 
         if (itemBound != null) {
             itemBound.setDead();

--- a/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
@@ -47,26 +47,19 @@ public class DisposableTurretProjectile extends TurretProjectile {
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj
-                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null
-                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+            Block hitBlock = worldObj.getBlock(
+                    movingobjectposition.blockX,
+                    movingobjectposition.blockY,
+                    movingobjectposition.blockZ);
+            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
                 // Go through non-solid block or turrets
                 return;
             }
         }
 
         if (movingobjectposition.entityHit != null && !worldObj.isRemote) {
-            if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-                if (worldObj.isAirBlock(
-                        movingobjectposition.blockX,
-                        movingobjectposition.blockY,
-                        movingobjectposition.blockZ)) {
-                    return;
-                }
-            }
-
             int damage = ConfigHandler.getDisposableTurretSettings().getDamage();
+            boolean wasAlive = !movingobjectposition.entityHit.isDead;
 
             if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
                 EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
@@ -81,14 +74,14 @@ public class DisposableTurretProjectile extends TurretProjectile {
                 elb.hurtResistantTime = 0;
 
                 float healthAfter = elb.getHealth();
-                if (healthBefore > 0 && healthAfter <= 0) {
+                if (wasAlive && healthBefore > 0 && healthAfter <= 0) {
                     turretBase.onKill(elb);
                 }
             } else {
                 movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("disposable"), damage);
                 movingobjectposition.entityHit.hurtResistantTime = 0;
 
-                if (movingobjectposition.entityHit.isDead) {
+                if (wasAlive && movingobjectposition.entityHit.isDead) {
                     turretBase.onKill(movingobjectposition.entityHit);
                 }
             }
@@ -99,6 +92,7 @@ public class DisposableTurretProjectile extends TurretProjectile {
         }
         this.setDead();
     }
+
 
     @Override
     protected float getGravityVelocity() {

--- a/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/DisposableTurretProjectile.java
@@ -47,11 +47,10 @@ public class DisposableTurretProjectile extends TurretProjectile {
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj.getBlock(
-                    movingobjectposition.blockX,
-                    movingobjectposition.blockY,
-                    movingobjectposition.blockZ);
-            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+            Block hitBlock = worldObj
+                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
                 // Go through non-solid block or turrets
                 return;
             }
@@ -92,7 +91,6 @@ public class DisposableTurretProjectile extends TurretProjectile {
         }
         this.setDead();
     }
-
 
     @Override
     protected float getGravityVelocity() {

--- a/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
@@ -35,10 +35,11 @@ public class FerroSlugProjectile extends TurretProjectile {
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj
-                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null
-                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+            Block hitBlock = worldObj.getBlock(
+                    movingobjectposition.blockX,
+                    movingobjectposition.blockY,
+                    movingobjectposition.blockZ);
+            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
                 // Go through non-solid block or turrets
                 return;
             }
@@ -55,6 +56,7 @@ public class FerroSlugProjectile extends TurretProjectile {
             }
 
             int damage = ConfigHandler.getRailgun_turret().getDamage();
+            boolean wasAlive = !movingobjectposition.entityHit.isDead;
 
             if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
                 EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
@@ -78,14 +80,14 @@ public class FerroSlugProjectile extends TurretProjectile {
                 elb.hurtResistantTime = 0;
 
                 float healthAfter = elb.getHealth();
-                if (healthBefore > 0 && healthAfter <= 0) {
+                if (wasAlive && healthBefore > 0 && healthAfter <= 0) {
                     turretBase.onKill(elb);
                 }
             } else {
                 movingobjectposition.entityHit.attackEntityFrom(new ArmorBypassDamageSource("ferroslug"), damage);
                 movingobjectposition.entityHit.hurtResistantTime = 0;
 
-                if (movingobjectposition.entityHit.isDead) {
+                if (wasAlive && movingobjectposition.entityHit.isDead) {
                     turretBase.onKill(movingobjectposition.entityHit);
                 }
             }

--- a/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
@@ -35,11 +35,10 @@ public class FerroSlugProjectile extends TurretProjectile {
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj.getBlock(
-                    movingobjectposition.blockX,
-                    movingobjectposition.blockY,
-                    movingobjectposition.blockZ);
-            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+            Block hitBlock = worldObj
+                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
                 // Go through non-solid block or turrets
                 return;
             }

--- a/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/FerroSlugProjectile.java
@@ -82,6 +82,9 @@ public class FerroSlugProjectile extends TurretProjectile {
                 movingobjectposition.entityHit.attackEntityFrom(new ArmorBypassDamageSource("ferroslug"), damage);
                 movingobjectposition.entityHit.hurtResistantTime = 0;
             }
+            if (movingobjectposition.entityHit.isDead) {
+                turretBase.onKill(movingobjectposition.entityHit);
+            }
         }
 
         this.setDead();

--- a/src/main/java/openmodularturrets/entity/projectiles/GrenadeProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/GrenadeProjectile.java
@@ -44,6 +44,7 @@ public class GrenadeProjectile extends TurretProjectile {
 
                 for (Entity mob : targets) {
                     int damage = ConfigHandler.getGrenadeTurretSettings().getDamage();
+                    boolean wasAlive = !mob.isDead;
 
                     if (isAmped && mob instanceof EntityLivingBase) {
                         EntityLivingBase elb = (EntityLivingBase) mob;
@@ -59,7 +60,7 @@ public class GrenadeProjectile extends TurretProjectile {
                         mob.hurtResistantTime = 0;
 
                         float healthAfter = elb.getHealth();
-                        if (healthBefore > 0 && healthAfter <= 0) {
+                        if (wasAlive && healthBefore > 0 && healthAfter <= 0) {
                             turretBase.onKill(elb);
                         }
                     } else {
@@ -67,7 +68,7 @@ public class GrenadeProjectile extends TurretProjectile {
                         mob.attackEntityFrom(new ArmorBypassDamageSource("grenade"), damage * 0.1F);
                         mob.hurtResistantTime = 0;
 
-                        if (mob.isDead) {
+                        if (wasAlive && mob.isDead) {
                             turretBase.onKill(mob);
                         }
                     }

--- a/src/main/java/openmodularturrets/entity/projectiles/GrenadeProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/GrenadeProjectile.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MovingObjectPosition;
@@ -44,31 +43,34 @@ public class GrenadeProjectile extends TurretProjectile {
                 List<Entity> targets = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, axis);
 
                 for (Entity mob : targets) {
-
                     int damage = ConfigHandler.getGrenadeTurretSettings().getDamage();
 
-                    if (isAmped) {
-                        if (mob instanceof EntityLivingBase) {
-                            EntityLivingBase elb = (EntityLivingBase) mob;
-                            damage += ((int) elb.getHealth() * (0.25 * amp_level));
-                        }
+                    if (isAmped && mob instanceof EntityLivingBase) {
+                        EntityLivingBase elb = (EntityLivingBase) mob;
+                        damage += ((int) elb.getHealth() * (0.25 * amp_level));
                     }
 
-                    if (mob instanceof EntityPlayer) {
-                        if (canDamagePlayer((EntityPlayer) mob)) {
-                            mob.attackEntityFrom(new NormalDamageSource("grenade"), damage * 0.9F);
-                            mob.attackEntityFrom(new ArmorBypassDamageSource("grenade"), damage * 0.1F);
-                            mob.hurtResistantTime = 0;
+                    if (mob instanceof EntityLivingBase) {
+                        EntityLivingBase elb = (EntityLivingBase) mob;
+                        float healthBefore = elb.getHealth();
+
+                        mob.attackEntityFrom(new NormalDamageSource("grenade"), damage * 0.9F);
+                        mob.attackEntityFrom(new ArmorBypassDamageSource("grenade"), damage * 0.1F);
+                        mob.hurtResistantTime = 0;
+
+                        float healthAfter = elb.getHealth();
+                        if (healthBefore > 0 && healthAfter <= 0) {
+                            turretBase.onKill(elb);
                         }
                     } else {
                         mob.attackEntityFrom(new NormalDamageSource("grenade"), damage * 0.9F);
                         mob.attackEntityFrom(new ArmorBypassDamageSource("grenade"), damage * 0.1F);
                         mob.hurtResistantTime = 0;
-                    }
-                    if (mob.isDead) {
-                        turretBase.onKill(mob);
-                    }
 
+                        if (mob.isDead) {
+                            turretBase.onKill(mob);
+                        }
+                    }
                 }
             }
             this.setDead();

--- a/src/main/java/openmodularturrets/entity/projectiles/GrenadeProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/GrenadeProjectile.java
@@ -65,6 +65,9 @@ public class GrenadeProjectile extends TurretProjectile {
                         mob.attackEntityFrom(new ArmorBypassDamageSource("grenade"), damage * 0.1F);
                         mob.hurtResistantTime = 0;
                     }
+                    if (mob.isDead) {
+                        turretBase.onKill(mob);
+                    }
 
                 }
             }

--- a/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
@@ -62,27 +62,30 @@ public class LaserProjectile extends TurretProjectile {
                     ConfigHandler.getTurretSoundVolume(),
                     random.nextFloat() + 0.5F);
 
-            if (movingobjectposition.entityHit != null && !worldObj.isRemote) {
-                int damage = ConfigHandler.getLaserTurretSettings().getDamage();
+            int damage = ConfigHandler.getLaserTurretSettings().getDamage();
 
-                if (isAmped) {
-                    if (movingobjectposition.entityHit instanceof EntityLivingBase) {
-                        EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
-                        damage += ((int) elb.getHealth() * (0.1 * amp_level));
-                    }
-                }
+            if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
+                EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
+                damage += ((int) elb.getHealth() * (0.1 * amp_level));
+            }
 
-                if (movingobjectposition.entityHit instanceof EntityPlayer) {
-                    if (canDamagePlayer((EntityPlayer) movingobjectposition.entityHit)) {
-                        movingobjectposition.entityHit.setFire(2);
-                        movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("laser"), damage);
-                        movingobjectposition.entityHit.hurtResistantTime = 0;
-                    }
-                } else {
-                    movingobjectposition.entityHit.setFire(2);
-                    movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("laser"), damage);
-                    movingobjectposition.entityHit.hurtResistantTime = 0;
+            if (movingobjectposition.entityHit instanceof EntityLivingBase) {
+                EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
+                float healthBefore = elb.getHealth();
+
+                elb.setFire(2);
+                elb.attackEntityFrom(new NormalDamageSource("laser"), damage);
+                elb.hurtResistantTime = 0;
+
+                float healthAfter = elb.getHealth();
+                if (healthBefore > 0 && healthAfter <= 0) {
+                    turretBase.onKill(elb);
                 }
+            } else {
+                movingobjectposition.entityHit.setFire(2);
+                movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("laser"), damage);
+                movingobjectposition.entityHit.hurtResistantTime = 0;
+
                 if (movingobjectposition.entityHit.isDead) {
                     turretBase.onKill(movingobjectposition.entityHit);
                 }

--- a/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
@@ -83,6 +83,9 @@ public class LaserProjectile extends TurretProjectile {
                     movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("laser"), damage);
                     movingobjectposition.entityHit.hurtResistantTime = 0;
                 }
+                if (movingobjectposition.entityHit.isDead) {
+                    turretBase.onKill(movingobjectposition.entityHit);
+                }
             }
         }
         this.setDead();

--- a/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
@@ -43,11 +43,10 @@ public class LaserProjectile extends TurretProjectile {
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj.getBlock(
-                    movingobjectposition.blockX,
-                    movingobjectposition.blockY,
-                    movingobjectposition.blockZ);
-            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+            Block hitBlock = worldObj
+                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
+            if (hitBlock != null
+                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
                 // Go through non-solid block or turrets
                 return;
             }

--- a/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/LaserProjectile.java
@@ -43,10 +43,11 @@ public class LaserProjectile extends TurretProjectile {
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj
-                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null
-                    && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
+            Block hitBlock = worldObj.getBlock(
+                    movingobjectposition.blockX,
+                    movingobjectposition.blockY,
+                    movingobjectposition.blockZ);
+            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || hitBlock instanceof BlockAbstractTurretHead)) {
                 // Go through non-solid block or turrets
                 return;
             }
@@ -63,6 +64,7 @@ public class LaserProjectile extends TurretProjectile {
                     random.nextFloat() + 0.5F);
 
             int damage = ConfigHandler.getLaserTurretSettings().getDamage();
+            boolean wasAlive = !movingobjectposition.entityHit.isDead;
 
             if (isAmped && movingobjectposition.entityHit instanceof EntityLivingBase) {
                 EntityLivingBase elb = (EntityLivingBase) movingobjectposition.entityHit;
@@ -78,7 +80,7 @@ public class LaserProjectile extends TurretProjectile {
                 elb.hurtResistantTime = 0;
 
                 float healthAfter = elb.getHealth();
-                if (healthBefore > 0 && healthAfter <= 0) {
+                if (wasAlive && healthBefore > 0 && healthAfter <= 0) {
                     turretBase.onKill(elb);
                 }
             } else {
@@ -86,7 +88,7 @@ public class LaserProjectile extends TurretProjectile {
                 movingobjectposition.entityHit.attackEntityFrom(new NormalDamageSource("laser"), damage);
                 movingobjectposition.entityHit.hurtResistantTime = 0;
 
-                if (movingobjectposition.entityHit.isDead) {
+                if (wasAlive && movingobjectposition.entityHit.isDead) {
                     turretBase.onKill(movingobjectposition.entityHit);
                 }
             }

--- a/src/main/java/openmodularturrets/entity/projectiles/RocketProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/RocketProjectile.java
@@ -131,6 +131,9 @@ public class RocketProjectile extends TurretProjectile {
                     mob.attackEntityFrom(new NormalDamageSource("rocket"), damage);
                     mob.hurtResistantTime = 0;
                 }
+                if (movingobjectposition.entityHit.isDead) {
+                    turretBase.onKill(movingobjectposition.entityHit);
+                }
             }
         }
         this.setDead();

--- a/src/main/java/openmodularturrets/entity/projectiles/RocketProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/RocketProjectile.java
@@ -82,10 +82,8 @@ public class RocketProjectile extends TurretProjectile {
         }
 
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj.getBlock(
-                    movingobjectposition.blockX,
-                    movingobjectposition.blockY,
-                    movingobjectposition.blockZ);
+            Block hitBlock = worldObj
+                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
             if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || worldObj.isAirBlock(
                     movingobjectposition.blockX,
                     movingobjectposition.blockY,

--- a/src/main/java/openmodularturrets/entity/projectiles/RocketProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/RocketProjectile.java
@@ -73,7 +73,6 @@ public class RocketProjectile extends TurretProjectile {
 
     @Override
     protected void onImpact(MovingObjectPosition movingobjectposition) {
-
         if (ConfigHandler.canRocketsHome && this.ticksExisted <= 5) {
             return;
         }
@@ -83,19 +82,20 @@ public class RocketProjectile extends TurretProjectile {
         }
 
         if (movingobjectposition.typeOfHit == MovingObjectPosition.MovingObjectType.BLOCK) {
-            Block hitBlock = worldObj
-                    .getBlock(movingobjectposition.blockX, movingobjectposition.blockY, movingobjectposition.blockZ);
-            if (hitBlock != null && !hitBlock.getMaterial().isSolid() || worldObj.isAirBlock(
+            Block hitBlock = worldObj.getBlock(
                     movingobjectposition.blockX,
                     movingobjectposition.blockY,
-                    movingobjectposition.blockZ)) {
-                // Go through non solid block
+                    movingobjectposition.blockZ);
+            if (hitBlock != null && (!hitBlock.getMaterial().isSolid() || worldObj.isAirBlock(
+                    movingobjectposition.blockX,
+                    movingobjectposition.blockY,
+                    movingobjectposition.blockZ))) {
+                // Go through non-solid block
                 return;
             }
         }
 
         if (!worldObj.isRemote) {
-
             worldObj.createExplosion(null, posX, posY, posZ, 0.1F, true);
             AxisAlignedBB axis = AxisAlignedBB.getBoundingBox(
                     this.posX - 5,
@@ -107,14 +107,12 @@ public class RocketProjectile extends TurretProjectile {
             List<Entity> targets = worldObj.getEntitiesWithinAABB(EntityLivingBase.class, axis);
 
             for (Entity mob : targets) {
-
                 int damage = ConfigHandler.getRocketTurretSettings().getDamage();
+                boolean wasAlive = !mob.isDead;
 
-                if (isAmped) {
-                    if (mob instanceof EntityLivingBase) {
-                        EntityLivingBase elb = (EntityLivingBase) mob;
-                        damage += ((int) elb.getHealth() * (0.25 * amp_level));
-                    }
+                if (isAmped && mob instanceof EntityLivingBase) {
+                    EntityLivingBase elb = (EntityLivingBase) mob;
+                    damage += ((int) elb.getHealth() * (0.25 * amp_level));
                 }
 
                 if (mob instanceof EntityPlayer) {
@@ -122,17 +120,16 @@ public class RocketProjectile extends TurretProjectile {
                         mob.attackEntityFrom(new NormalDamageSource("rocket"), damage);
                         mob.hurtResistantTime = 0;
                     }
-                }
-
-                if (ConfigHandler.isCanRocketsHurtEnderDragon() && mob instanceof EntityDragon) {
+                } else if (ConfigHandler.isCanRocketsHurtEnderDragon() && mob instanceof EntityDragon) {
                     ((EntityDragon) mob).setHealth(((EntityDragon) mob).getHealth() - damage);
                     mob.hurtResistantTime = 0;
                 } else {
                     mob.attackEntityFrom(new NormalDamageSource("rocket"), damage);
                     mob.hurtResistantTime = 0;
                 }
-                if (movingobjectposition.entityHit.isDead) {
-                    turretBase.onKill(movingobjectposition.entityHit);
+
+                if (wasAlive && mob.isDead) {
+                    turretBase.onKill(mob);
                 }
             }
         }

--- a/src/main/java/openmodularturrets/entity/projectiles/TurretProjectile.java
+++ b/src/main/java/openmodularturrets/entity/projectiles/TurretProjectile.java
@@ -17,7 +17,7 @@ public abstract class TurretProjectile extends EntityThrowable {
     boolean isAmped;
     int amp_level;
     ItemStack ammo;
-    private TurretBase turretBase;
+    protected TurretBase turretBase;
 
     TurretProjectile(World p_i1776_1_) {
         super(p_i1776_1_);

--- a/src/main/java/openmodularturrets/network/messages/MessageTurretBase.java
+++ b/src/main/java/openmodularturrets/network/messages/MessageTurretBase.java
@@ -22,7 +22,7 @@ import openmodularturrets.tileentity.turretbase.TurretBase;
  */
 public class MessageTurretBase implements IMessage {
 
-    private int x, y, z, rfStorage, yAxisDetect;
+    private int x, y, z, rfStorage, yAxisDetect, killCount;
     private boolean attacksMobs, attacksNeutrals, attacksPlayers, multiTargeting, waitForTrustedPlayer;
     private String owner, ownerName;
     private List<TrustedPlayer> trustedPlayers = new ArrayList<>();
@@ -45,7 +45,9 @@ public class MessageTurretBase implements IMessage {
                 ((TurretBase) tileEntity).setAttacksPlayers(message.attacksPlayers);
                 ((TurretBase) tileEntity).setMultiTargeting(message.multiTargeting);
                 ((TurretBase) tileEntity).setTrustedPlayers(message.trustedPlayers);
+                ((TurretBase) tileEntity).setKillCount(message.killCount);
                 ((TurretBase) tileEntity).waitForTrustedPlayer = message.waitForTrustedPlayer;
+
                 ((TurretBase) tileEntity).camoStack = message.camoStack;
             }
             return null;
@@ -67,7 +69,9 @@ public class MessageTurretBase implements IMessage {
             this.attacksPlayers = TurretBase.isAttacksPlayers();
             this.multiTargeting = TurretBase.isMultiTargeting();
             this.trustedPlayers = TurretBase.getTrustedPlayers();
+            this.killCount = TurretBase.getKillCount();
             this.waitForTrustedPlayer = TurretBase.waitForTrustedPlayer;
+
             this.camoStack = TurretBase.camoStack;
         }
     }
@@ -88,6 +92,7 @@ public class MessageTurretBase implements IMessage {
         this.attacksPlayers = buf.readBoolean();
         this.multiTargeting = buf.readBoolean();
         this.waitForTrustedPlayer = buf.readBoolean();
+        this.killCount = buf.readInt();
         this.camoStack = ByteBufUtils.readItemStack(buf);
         int lengthOfTPList = buf.readInt();
         if (lengthOfTPList > 0) {
@@ -121,6 +126,7 @@ public class MessageTurretBase implements IMessage {
         buf.writeBoolean(attacksPlayers);
         buf.writeBoolean(multiTargeting);
         buf.writeBoolean(waitForTrustedPlayer);
+        buf.writeInt(killCount);
         ByteBufUtils.writeItemStack(buf, camoStack);
         buf.writeInt(trustedPlayers.size());
         if (trustedPlayers.size() > 0) {

--- a/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
+++ b/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
@@ -97,9 +97,12 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
         this.active = true;
         this.ticks = 0;
     }
-
+    public void onKill(Entity entity) {
+         this.killCount++;
+    }
+        
     private static void updateRedstoneReactor(TurretBase base) {
-        if (!TurretHeadUtil.hasRedstoneReactor(base)) {
+        if (!TurretHeadUtil.asRedstoneReactor(base)) {
             return;
         }
 

--- a/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
+++ b/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
@@ -82,6 +82,7 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
     private double storageEU;
     private boolean wasAddedToEnergyNet = false;
     public boolean waitForTrustedPlayer = false;
+    private int killCount = 0;
 
     public TurretBase(int MaxEnergyStorage, int MaxIO) {
         super();

--- a/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
+++ b/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.logging.Logger;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -627,6 +628,10 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
 
     public boolean isMultiTargeting() {
         return multiTargeting;
+    }
+
+    public int getKillCount() {
+        return killCount;
     }
 
     public void setMultiTargeting(boolean multiTargeting) {

--- a/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
+++ b/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
@@ -98,14 +98,12 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
         this.active = true;
         this.ticks = 0;
     }
+
     public void onKill(Entity entity) {
-         this.killCount++;
+        this.killCount++;
     }
-        
+
     private static void updateRedstoneReactor(TurretBase base) {
-        if (!TurretHeadUtil.asRedstoneReactor(base)) {
-            return;
-        }
 
         if (ConfigHandler.getRedstoneReactorAddonGen()
                 < (base.getMaxEnergyStored(ForgeDirection.UNKNOWN) - base.getEnergyStored(ForgeDirection.UNKNOWN))) {
@@ -318,6 +316,7 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
         par1.setBoolean("shouldConcealTurrets", shouldConcealTurrets);
         par1.setBoolean("multiTargeting", multiTargeting);
         par1.setDouble("storageEU", storageEU);
+        par1.setInteger("killCount", killCount);
 
         NBTTagList itemList = new NBTTagList();
 
@@ -353,6 +352,7 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
         this.attacksPlayers = par1.getBoolean("attacksPlayers");
         this.shouldConcealTurrets = par1.getBoolean("shouldConcealTurrets");
         this.multiTargeting = par1.getBoolean("multiTargeting");
+        this.killCount = par1.getInteger("killCount");
 
         if (getPlayerUIDUnstable(par1.getString("owner")) != null) {
             this.owner = getPlayerUIDUnstable(par1.getString("owner")).toString();
@@ -632,6 +632,10 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
 
     public int getKillCount() {
         return killCount;
+    }
+
+    public void setKillCount(int killCount) {
+        this.killCount = killCount;
     }
 
     public void setMultiTargeting(boolean multiTargeting) {

--- a/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
+++ b/src/main/java/openmodularturrets/tileentity/turretbase/TurretBase.java
@@ -104,6 +104,9 @@ public abstract class TurretBase extends TileEntityContainer implements IEnergyH
     }
 
     private static void updateRedstoneReactor(TurretBase base) {
+        if (!TurretHeadUtil.hasRedstoneReactor(base)) {
+            return;
+        }
 
         if (ConfigHandler.getRedstoneReactorAddonGen()
                 < (base.getMaxEnergyStored(ForgeDirection.UNKNOWN) - base.getEnergyStored(ForgeDirection.UNKNOWN))) {


### PR DESCRIPTION
This PR introduces several updates and new features to the OpenModularTurrets project, specifically focusing on tracking the kill count for turrets and displaying this information in the GUI. The following changes have been made:

1. **TurretBase.java**:
   - Added a `killCount` field to track the number of kills made by the turret.
   - Implemented `onKill` method to increment the kill count when an entity is killed.
   - Added getter and setter methods for `killCount`.
   - Updated `writeToNBT` and `readFromNBT` methods to save and load the kill count.
   
2. **GUI Updates**:
   - Added the kill count display to the GUI for all turret tiers (TurretBaseTierOneGui, TurretBaseTierTwoGui, TurretBaseTierThreeGui, TurretBaseTierFourGui, TurretBaseTierFiveGui). The kill count is now shown as part of the target information.

3. **Projectile Updates**:
   - Updated various projectile classes (BlazingClayProjectile, BulletProjectile, DisposableTurretProjectile, FerroSlugProjectile, GrenadeProjectile, LaserProjectile, RocketProjectile) to ensure that kills are only counted once per entity, even if multiple projectiles hit the entity simultaneously.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/18740

